### PR TITLE
BUG: Specify the encoding of the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,3 +232,4 @@ Contributors
 
 -   Charles H Camp Jr
 -   Charles Le Losq (charles.lelosq@anu.edu.au)
+-   Robert Kern (rkern@enthought.com)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ Setup for pyMCR
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='pyMCR',


### PR DESCRIPTION
There is a UTF-8 character sequence in the `README`, so it must be opened with that encoding specified. Otherwise, on OSes with a non-UTF-8 locale, the reading of the text will fail.