### PR TITLE
Update CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ and Dependency Specification <https://www.python.org/dev/peps/pep-0440/>`_.
 -   Documentation: https://pages.nist.gov/pyMCR or build locally via Sphinx
 -   Added Jupyter Notebook that generates images from forthcoming publication.
 -   Perform semi-learning: assigning some input ST or C components to be static in fit method.
+-   pymcr.mcr.McrAls to pymcr.mcr.McrAR 
 -   **Constraints**
 
     -   Non-negative cumulative summation


### PR DESCRIPTION
pymcr.mcr.McrAls was changed to pymcr.mcr.McrAR.

This breaks a bit code written in 0.2.0. Easy to fix but best to document this in the log.