### PR TITLE
Update mcr.py to avoid infrequent Nan error when working with small simple datasets

### DIFF
--- a/pymcr/mcr.py
+++ b/pymcr/mcr.py
@@ -332,6 +332,9 @@ class McrAR:
                 self.c_regressor.fit(self.ST_.T, D.T, **self.c_fit_kwargs)
                 C_temp = self.c_regressor.coef_
 
+                # Remove Nan values in C_temp
+                C_temp = _np.nan_to_num(C_temp)
+                
                 # Apply fixed C's
                 if c_fix:
                     C_temp[:, c_fix] = self.C_[:, c_fix]


### PR DESCRIPTION
In some dataset mcr.py will create a C_temp with Nan values.
If the Nan values are not removed, the script will crash at line 421.

I encountered the Nan value problem where C is unknown and an SVD guess is provided for ST. I didn't look into the problem further, but this fix does solve the issue if present, and if not present the added function adds infinitesimally to the total run time. This problem Seems to be more of an issue in small datasets with very high S/N and somewhat small ST. 
NOTE: This fix is really just a band aid. It corrects the problem, but does not fix the source.